### PR TITLE
[F] Set sql_mode to match Ubuntu defaults

### DIFF
--- a/scaffold/october/script/setup
+++ b/scaffold/october/script/setup
@@ -36,6 +36,9 @@ else
   mysql -uroot -e "CREATE DATABASE IF NOT EXISTS $db";
 fi
 
+echo "===> Enabling strict mode for MySQL"
+mysql -uroot -e "SET GLOBAL sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';"
+
 # Setup the database
 php artisan october:up
 

--- a/scaffold/typo3/script/setup
+++ b/scaffold/typo3/script/setup
@@ -35,6 +35,9 @@ else
   mysql -uroot -e "CREATE DATABASE IF NOT EXISTS $db";
 fi
 
+echo "===> Enabling strict mode for MySQL"
+mysql -uroot -e "SET GLOBAL sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';"
+
 # Install or update Foreman
 if [ -z "$RAILS_ENV" ] && [ -z "$RACK_ENV" ]; then
   echo "==> Installing or updating Foreman gem…"


### PR DESCRIPTION
@lthurston I might have you test this out. We alternatively could create a .sql file and use that in both October and TYPO3 scaffolds but the reality is they will persist within the local project so I don't really see that as an advantage. This also assumes one is running mysql@5.7 not the standard mysql (8) homebrew package.
